### PR TITLE
fix: handle stale/closed database connections

### DIFF
--- a/tests/open_sgid/test_DatabaseConnection.py
+++ b/tests/open_sgid/test_DatabaseConnection.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# * coding: utf8 *
+"""
+A module that contains tests for the open_sgid.DatabaseConnection class
+"""
+
+from collections import namedtuple
+from typing import NamedTuple
+from unittest import mock
+
+from masquerade.providers.open_sgid import DatabaseConnection
+
+
+@mock.patch('masquerade.providers.open_sgid.psycopg2')
+def test_query(psycopg_mock):
+    expected_data = ['blah']
+    Cursor = namedtuple('Cursor', ['execute', 'fetchall'])
+    cursor_mock = Cursor(lambda _: None, lambda: expected_data)
+    Connection = namedtuple('Connection', ['cursor', 'closed'])
+    psycopg_mock.connect.return_value = Connection(lambda: cursor_mock, False)
+
+    database = DatabaseConnection()
+
+    result = database.query('query text')
+
+    assert result == expected_data

--- a/tests/open_sgid/test_Table.py
+++ b/tests/open_sgid/test_Table.py
@@ -14,24 +14,22 @@ from masquerade.providers.open_sgid import POINT, POLYGON, AddressPointTable, Ta
 table = Table('table_name', 'name', [], POLYGON)
 
 
-@mock.patch('masquerade.providers.open_sgid.connection')
-def test_get_suggestions(connect_mock):
+@mock.patch('masquerade.providers.open_sgid.database')
+def test_get_suggestions(database_mock):
     mocked_results = [[1, 'search text'], [2, 'more search text']]
-    cursor_mock = connect_mock.cursor.return_value
-    cursor_mock.fetchall.return_value = mocked_results
+    database_mock.query.return_value = mocked_results
 
     suggestions = table.get_suggestions('blah', 10)
 
     assert len(suggestions) == 2
-    cursor_mock.execute.assert_called_with(Contains('ilike \'blah%\''))
+    database_mock.query.assert_called_with(Contains('ilike \'blah%\''))
 
 
-@mock.patch('masquerade.providers.open_sgid.connection')
-def test_get_candidate_from_magic_key(connect_mock):
-    mocked_result = [1, 'match text', 1, 2, 3, 4, 5, 6]
+@mock.patch('masquerade.providers.open_sgid.database')
+def test_get_candidate_from_magic_key(database_mock):
+    mocked_result = [[1, 'match text', 1, 2, 3, 4, 5, 6]]
 
-    cursor_mock = connect_mock.cursor.return_value
-    cursor_mock.fetchone.return_value = mocked_result
+    database_mock.query.return_value = mocked_result
 
     candidate = table.get_candidate_from_magic_key(1, 3857)
 


### PR DESCRIPTION
This was prompted when I started getting these errors in cloud run:
![image](https://user-images.githubusercontent.com/1326248/113356291-3fd26180-92ff-11eb-9ddc-a058186944a3.png)

Hopefully this should mean that we always have an open connection to the database.