### PR TITLE
Add all SGID attributes to matched record results

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,10 @@ setup(
         'flask-cors==3.0.*',
         'psycopg2-binary==2.8.*',
         'agrc-sweeper==1.1.*',
+
+        #: flask uses this by default if installed
+        #: this handles decimals as returned from open sgid data better than the default json library
+        'simplejson==3.17.*',
     ],
     extras_require={
         'tests': [

--- a/tests/open_sgid/test_DatabaseConnection.py
+++ b/tests/open_sgid/test_DatabaseConnection.py
@@ -27,3 +27,26 @@ def test_query(psycopg_mock):
 
     assert result == expected_data
     assert psycopg_mock.connect.call_count == 1
+
+
+@mock.patch('masquerade.providers.open_sgid.psycopg2')
+def test_get_magic_key_record(psycopg_mock):
+    expected_data = ['blah']
+    Cursor = namedtuple('Cursor', ['execute', 'fetchone', 'description'])
+    cursor_mock = Cursor(
+        lambda _: None, lambda: expected_data,
+        ['xid', 'search_field', 'x', 'y', 'xmin', 'xmax', 'ymin', 'ymax', 'another_field', 'shape']
+    )
+    Connection = namedtuple('Connection', ['cursor', 'closed'])
+    open_connection = Connection(lambda: cursor_mock, 0)
+    closed_connection = Connection(lambda: cursor_mock, 1)
+    psycopg_mock.connect.side_effect = [open_connection, closed_connection]
+
+    database = DatabaseConnection()
+
+    record, field_names = database.get_magic_key_record('query text')
+
+    assert record[0] == 'blah'
+
+    #: should filter out shape value
+    assert not 'shape' in field_names

--- a/tests/open_sgid/test_Table.py
+++ b/tests/open_sgid/test_Table.py
@@ -51,9 +51,11 @@ def test_get_suggestions_numeric_with_text_in_query(database_mock):
 
 @mock.patch('masquerade.providers.open_sgid.database')
 def test_get_candidate_from_magic_key(database_mock):
-    mocked_result = [[1, 'match text', 1, 2, 3, 4, 5, 6]]
+    mocked_result = [1, 'match text', 1, 2, 3, 4, 5, 6, 'value']
 
-    database_mock.query.return_value = mocked_result
+    database_mock.get_magic_key_record.return_value = (
+        mocked_result, ['xid', 'search_field', 'x', 'y', 'xmin', 'xmax', 'ymin', 'ymax', 'another_field']
+    )
 
     candidate = table.get_candidate_from_magic_key(1, 3857)
 
@@ -114,9 +116,11 @@ def test_custom_get_suggestion_from_record(database_mock):
         get_suggestion_text_from_record=lambda matched_text, *rest: f'test {matched_text}'
     )
 
-    mocked_result = [[1, 'match text', 1, 2, 3, 4, 5, 6]]
+    mocked_result = [1, 'match text', 1, 2, 3, 4, 5, 6, 'value']
 
-    database_mock.query.return_value = mocked_result
+    database_mock.get_magic_key_record.return_value = (
+        mocked_result, ['xid', 'search_field', 'x', 'y', 'xmin', 'xmax', 'ymin', 'ymax', 'another_field']
+    )
 
     candidate = table.get_candidate_from_magic_key(1, 3857)
 


### PR DESCRIPTION
Closes #26

Here are some examples of how the data looks in Pro:

Before:
![image](https://user-images.githubusercontent.com/1326248/118013448-5eb91000-b30f-11eb-8ce9-83835169379b.png)

After:
![image](https://user-images.githubusercontent.com/1326248/118013280-2f0a0800-b30f-11eb-8de0-b3ac676ed0d9.png)
![image](https://user-images.githubusercontent.com/1326248/118013288-30d3cb80-b30f-11eb-924d-3276afa570d9.png)
