### PR TITLE
Update Political Districts and add search key

### DIFF
--- a/src/masquerade/providers/open_sgid.py
+++ b/src/masquerade/providers/open_sgid.py
@@ -135,7 +135,7 @@ class Table():
             int(search_text)
             where = f'{self.search_field} = {search_text}'
         else:
-            raise ValueError(f'Invalid search_field_type: {self.search_field_type}')
+            raise Exception(f'Invalid search_field_type: {self.search_field_type}')
 
         return f'''
             select {self.get_out_fields()} from {self.table_name}

--- a/src/masquerade/providers/open_sgid.py
+++ b/src/masquerade/providers/open_sgid.py
@@ -11,6 +11,8 @@ DATABASE = 'opensgid'
 AGRC = 'agrc'
 HOST = 'opensgid.agrc.utah.gov'
 SPLITTER = '-'
+
+#: geometry types
 POINT = 'point'
 POLYGON = 'polygon'
 
@@ -21,6 +23,7 @@ ADDSYSTEM = 'addsystem'
 CITY = 'city'
 NAME = 'name'
 
+#: search field types
 TEXT = 'text'
 NUMERIC = 'numeric'
 
@@ -93,7 +96,13 @@ class Table():
     ):
         self.table_name = table_name
         self.search_field = search_field
+
+        if geometry_type not in [POINT, POLYGON]:
+            raise Exception(f'Invalid geometry_type: {geometry_type}')
         self.geometry_type = geometry_type
+
+        if search_field_type not in [TEXT, NUMERIC]:
+            raise Exception(f'Invalid search_field_type: {search_field_type}')
         self.search_field_type = search_field_type
         self.additional_out_fields = additional_out_fields or []
 

--- a/src/masquerade/providers/open_sgid.py
+++ b/src/masquerade/providers/open_sgid.py
@@ -282,18 +282,32 @@ class FullTextTable(Table):
 #: these should be ordered in the order that you want results to show up in
 TABLES = [
     Table(
-        'opensgid.political.house_districts_2012',
+        'opensgid.political.house_districts_2022_to_2032',
         'dist',
         POLYGON,
         search_field_type=NUMERIC,
-        get_suggestion_text_from_record=lambda text, *rest: f'Utah House District {text}'
+        get_suggestion_text_from_record=lambda text, *rest: f'Utah House District {text}',
     ),
     Table(
-        'opensgid.political.senate_districts_2012',
+        'opensgid.political.school_board_districts_2022_to_2032',
         'dist',
         POLYGON,
         search_field_type=NUMERIC,
-        get_suggestion_text_from_record=lambda text, *rest: f'Utah Senate District {text}'
+        get_suggestion_text_from_record=lambda text, *rest: f'Utah School Board District {text}',
+    ),
+    Table(
+        'opensgid.political.senate_districts_2022_to_2032',
+        'dist',
+        POLYGON,
+        search_field_type=NUMERIC,
+        get_suggestion_text_from_record=lambda text, *rest: f'Utah Senate District {text}',
+    ),
+    Table(
+        'opensgid.political.us_congress_districts_2022_to_2032',
+        'district',
+        POLYGON,
+        search_field_type=NUMERIC,
+        get_suggestion_text_from_record=lambda text, *rest: f'Utah U.S. Congressional District {text}',
     ),
     AddressPointTable('opensgid.location.address_points', FULLADD, POINT, additional_out_fields=[ADDSYSTEM, CITY]),
     Table(

--- a/tests/open_sgid/test_AddressPointTable.py
+++ b/tests/open_sgid/test_AddressPointTable.py
@@ -6,7 +6,7 @@ A module that contains tests for the open_sgid.AddressPointTable class
 
 from masquerade.providers.open_sgid import ADDSYSTEM, CITY, FULLADD, POINT, AddressPointTable
 
-table = AddressPointTable('table_name', FULLADD, [ADDSYSTEM, CITY], POINT)
+table = AddressPointTable('table_name', FULLADD, POINT, additional_out_fields=[ADDSYSTEM, CITY])
 
 
 def test_get_suggestion_from_record_with_city():


### PR DESCRIPTION
By default, Esri's locator widgets do not send a request to the suggest endpoint until the user types at least three characters. This was a problem for the political district tables since their numbers are only one or two digits.

So if the user typed "2" or "20" they would not get any results from these tables. This commit allows them to type "2 ho" or "2 dist" and get results.

![image](https://user-images.githubusercontent.com/1326248/148833509-4dafb18e-4128-4d79-aecc-fe437acf3880.png)
![image](https://user-images.githubusercontent.com/1326248/148833521-a5d0b245-3ce5-45ce-9cd6-fcdbd95ebd14.png)
