### PR TITLE
fix: handle invalid magicKey values

### DIFF
--- a/src/masquerade/main.py
+++ b/src/masquerade/main.py
@@ -191,6 +191,9 @@ def find_candidates():
     request_wkid, out_spatial_reference = get_out_spatial_reference(request)
 
     if magic_key is not None:
+        if open_sgid.SPLITTER not in magic_key:
+            return f'Invalid magicKey: {magic_key}', 400
+
         candidate = open_sgid.get_candidate_from_magic_key(magic_key, out_spatial_reference)
         candidates = [candidate]
     else:

--- a/tests/test_masquerade.py
+++ b/tests/test_masquerade.py
@@ -40,11 +40,20 @@ def test_base_geocode_route(test_client):
 def test_find_candidates(get_candidate_mock, test_client):
     get_candidate_mock.return_value = 'blah'
 
-    response = test_client.get(f'{GEOCODE_SERVER_ROUTE}/findAddressCandidates?magicKey=1&outSR={{"wkid": 102100}}')
+    response = test_client.get(
+        f'{GEOCODE_SERVER_ROUTE}/findAddressCandidates?magicKey=1-table&outSR={{"wkid": 102100}}'
+    )
     response_json = json.loads(response.data)
 
     assert response_json['candidates'][0] == 'blah'
     assert response_json['spatialReference']['latestWkid'] == 3857
+
+
+def test_find_candidates_invalid_magic_key(test_client):
+    response = test_client.get(f'{GEOCODE_SERVER_ROUTE}/findAddressCandidates?magicKey=invalid')
+
+    assert response.status_code == 400
+    assert b'Invalid magicKey' in response.data
 
 
 @mock.patch('masquerade.main.open_sgid.get_candidate_from_magic_key')
@@ -52,7 +61,7 @@ def test_find_candidates_with_out_out_sr(get_candidate_mock, test_client):
     #: Pro doesn't include the outSR in these requests if the default matches the map
     get_candidate_mock.return_value = 'blah'
 
-    response = test_client.get(f'{GEOCODE_SERVER_ROUTE}/findAddressCandidates?magicKey=1')
+    response = test_client.get(f'{GEOCODE_SERVER_ROUTE}/findAddressCandidates?magicKey=1-table')
     response_json = json.loads(response.data)
 
     assert response_json['candidates'][0] == 'blah'


### PR DESCRIPTION
I've seen a few requests come in with strange magic keys that are causing 500 errors. This commit handles those situations and returns a helpful error message with a 400 status code.