### PR TITLE
Disable strict slashes

### DIFF
--- a/src/masquerade/main.py
+++ b/src/masquerade/main.py
@@ -32,6 +32,7 @@ RATE_LIMIT_SECONDS = (0.015, 0.03)
 BATCH_SIZE = 25
 
 app = Flask(__name__)
+app.url_map.strict_slashes = False
 FlaskJSON(app)
 CORS(app)
 log = create_logger(app)


### PR DESCRIPTION
it appears the leaflet developers assume esri servers handle routes this way

closes #233 