### PR TITLE
ci: add cooldown settings with org package excludes to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       semver-major-days: 60
       semver-minor-days: 14
       semver-patch-days: 7
+      exclude:
+        - ugrc-*
+        - agrc-*
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -30,3 +33,5 @@ updates:
         dependency-type: production
     cooldown:
       default-days: 10
+      exclude:
+        - agrc/*


### PR DESCRIPTION
This PR adds [cooldown settings](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) to the dependabot configuration for all package ecosystems.

## What this does:

- Allows dependabot to delay including dependencies for a configurable number of days
- Excludes organization packages (`ugrc-*`, `@ugrc/*`, `agrc/*`) from cooldown delays so they update immediately

## Benefits:

- The community finds supply chain vulnerabilities and bugs before they are included in a pull request
- Organization packages are updated immediately without delays for faster internal development cycles
